### PR TITLE
Modified pattern on url.replace call so that it matches the actual url t...

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -523,7 +523,7 @@
         param = _ref[_i];
         if (param.paramType === 'path') {
           if (args[param.name]) {
-            url = url.replace("{" + param.name + "}", encodeURIComponent(args[param.name]));
+            url = url.replace(":" + param.name, encodeURIComponent(args[param.name]));
             delete args[param.name];
           } else {
             throw "" + param.name + " is a required path param.";


### PR DESCRIPTION
I did this modification so the proper URL is requested by the UI. Otherwise URLs are tokenized as :id/:otherData.json but the replace is looking for something like {id}/{otherData} so it ends up requesting http://sampleendpoint.com/api/:id/:otherdata.json 
