### PR TITLE
Supporting empty bodies and showing the status text as well in responses

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -108,10 +108,13 @@ class OperationView extends Backbone.View
   # puts the response data in UI
   showStatus: (data) ->
     try
-      response_body = "<pre>" + JSON.stringify(JSON.parse(data.responseText), null, 2).replace(/\n/g, "<br>") + "</pre>"
+      if response_body.length > 0
+        response_body = "<pre>" + JSON.stringify(JSON.parse(data.responseText), null, 2).replace(/\n/g, "<br>") + "</pre>"
+      else
+        response_body = "<pre style='color:dimgrey'>[No Content]</pre>"
     catch error
       response_body = "<span style='color:red'>&nbsp;&nbsp;&nbsp;[unable to parse as json; raw response below]</span><br><pre>" + data.responseText + "</pre>"
-    $(".response_code", $(@el)).html "<pre>" + data.status + "</pre>"
+    $(".response_code", $(@el)).html "<pre>" + data.status + ' ' + data.statusText + "</pre>"
     $(".response_body", $(@el)).html response_body
     $(".response_headers", $(@el)).html "<pre>" + data.getAllResponseHeaders() + "</pre>"
     $(".response", $(@el)).slideDown()


### PR DESCRIPTION
I did a small improvement to responses, as I was treating 204 responses and the explorer was showing me that as error, but 204 is fine and should have no body. Thus, I added a grey `[No Content]` instead of the usual red error message in the response body.

Additionally, I've added the status text besides the status code, as this can be handy for those who are still getting used to the HTTP protocol and don't know much of its response codes (and thus something like 405 is strange and having to develop with a list of status code side by side is boring). Besides that, the status text wasn't being displayed in other areas.

However, I was unable to compile the build. I really think this repository should, at least, be open to issues so we could better contribute to it.
I installed the required packages using `npm install -g coffee-script handlebars` (why not use a `package.json` like Swagger?) and then ran `cake dist`. This changed a lot of stuff in the compiled code and it was not working anymore. Also, the file `handlebars.runtime-1.0.0.beta.6.js` was removed.

I made sure the code will work replicating the changes manually in the dist code.
